### PR TITLE
Fix imports in `__init__.py`

### DIFF
--- a/src/polytropon/__init__.py
+++ b/src/polytropon/__init__.py
@@ -1,0 +1,2 @@
+from . import adapters, utils
+from .polytropon import VARIANT2CLASS, SkilledMixin

--- a/src/polytropon/polytropon.py
+++ b/src/polytropon/polytropon.py
@@ -5,12 +5,12 @@ from scipy import special
 import torch
 from torch import nn
 
-from adapters import (
+from .adapters import (
     HyperLoRALinear,
     SkilledLoRALinear,
     SkilledLTSFTLinear,
 )
-from utils import replace_layers, inform_layers
+from .utils import replace_layers, inform_layers
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Closes https://github.com/McGill-NLP/polytropon/issues/1

---

Now you can import polytropon directly:
```python
import polytropon

print(polytropon.adapters)
print(polytropon.utils)
print(polytropon.SkilledMixin)
```

Or import specific modules from it:
```python
from polytropon import SkilledMixin
```